### PR TITLE
Fix NPE from TaskStatusResponse

### DIFF
--- a/src/main/java/org/pbs/sgladapter/service/SGLAdapterService.java
+++ b/src/main/java/org/pbs/sgladapter/service/SGLAdapterService.java
@@ -144,8 +144,12 @@ public class SGLAdapterService implements ISGLAdapterService {
             SGLStatusResponse sglStatusResponse = om.readValue(response, SGLStatusResponse.class);
             Job job = sglStatusResponse.getJob();
 
-            String exitStateMssg = job.getExitStateMessage();
-            String queuedStateMssg = job.getQueuedStateMessage();
+            String exitStateMssg = null;
+            String queuedStateMssg = null;
+            if (job != null) {
+                exitStateMssg = job.getExitStateMessage();
+                queuedStateMssg = job.getQueuedStateMessage();
+            }
 
             if (exitStateMssg == null || queuedStateMssg == null) {
                 taskStatus = TaskStatus.COMPLETED_FAILED;


### PR DESCRIPTION
This occurs when we get a failure from SGL, leaving the job property null.